### PR TITLE
Fix most linting errors

### DIFF
--- a/sqlmodel/engine/result.py
+++ b/sqlmodel/engine/result.py
@@ -1,4 +1,4 @@
-from typing import Generic, Iterator, List, Optional, Sequence, TypeVar
+from typing import Generic, Iterator, List, Optional, Sequence, Tuple, TypeVar
 
 from sqlalchemy.engine.result import Result as _Result
 from sqlalchemy.engine.result import ScalarResult as _ScalarResult
@@ -35,7 +35,7 @@ class ScalarResult(_ScalarResult[_T], Generic[_T]):
         return super().one()
 
 
-class Result(_Result[_T], Generic[_T]):
+class Result(_Result[Tuple[_T]], Generic[_T]):
     def scalars(self, index: int = 0) -> ScalarResult[_T]:
         return super().scalars(index)  # type: ignore
 

--- a/sqlmodel/engine/result.py
+++ b/sqlmodel/engine/result.py
@@ -67,7 +67,7 @@ class Result(_Result[Tuple[_T]], Generic[_T]):
         return super().one_or_none()  # type: ignore
 
     def scalar_one(self) -> _T:
-        return super().scalar_one()  # type: ignore
+        return super().scalar_one()
 
     def scalar_one_or_none(self) -> Optional[_T]:
         return super().scalar_one_or_none()
@@ -76,4 +76,4 @@ class Result(_Result[Tuple[_T]], Generic[_T]):
         return super().one()  # type: ignore
 
     def scalar(self) -> Optional[_T]:
-        return super().scalar()  # type: ignore
+        return super().scalar()

--- a/sqlmodel/engine/result.py
+++ b/sqlmodel/engine/result.py
@@ -1,4 +1,4 @@
-from typing import Generic, Iterator, List, Optional, Sequence, Tuple, TypeVar
+from typing import Generic, Iterator, Optional, Sequence, Tuple, TypeVar
 
 from sqlalchemy.engine.result import Result as _Result
 from sqlalchemy.engine.result import ScalarResult as _ScalarResult
@@ -36,44 +36,4 @@ class ScalarResult(_ScalarResult[_T], Generic[_T]):
 
 
 class Result(_Result[Tuple[_T]], Generic[_T]):
-    def scalars(self, index: int = 0) -> ScalarResult[_T]:
-        return super().scalars(index)  # type: ignore
-
-    def __iter__(self) -> Iterator[_T]:  # type: ignore
-        return super().__iter__()  # type: ignore
-
-    def __next__(self) -> _T:  # type: ignore
-        return super().__next__()  # type: ignore
-
-    def partitions(self, size: Optional[int] = None) -> Iterator[List[_T]]:  # type: ignore
-        return super().partitions(size)  # type: ignore
-
-    def fetchall(self) -> List[_T]:  # type: ignore
-        return super().fetchall()  # type: ignore
-
-    def fetchone(self) -> Optional[_T]:  # type: ignore
-        return super().fetchone()  # type: ignore
-
-    def fetchmany(self, size: Optional[int] = None) -> List[_T]:  # type: ignore
-        return super().fetchmany()  # type: ignore
-
-    def all(self) -> List[_T]:  # type: ignore
-        return super().all()  # type: ignore
-
-    def first(self) -> Optional[_T]:  # type: ignore
-        return super().first()  # type: ignore
-
-    def one_or_none(self) -> Optional[_T]:  # type: ignore
-        return super().one_or_none()  # type: ignore
-
-    def scalar_one(self) -> _T:
-        return super().scalar_one()
-
-    def scalar_one_or_none(self) -> Optional[_T]:
-        return super().scalar_one_or_none()
-
-    def one(self) -> _T:  # type: ignore
-        return super().one()  # type: ignore
-
-    def scalar(self) -> Optional[_T]:
-        return super().scalar()
+    ...

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -11,6 +11,7 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    ForwardRef,
     List,
     Mapping,
     Optional,
@@ -29,7 +30,7 @@ from pydantic.fields import SHAPE_SINGLETON
 from pydantic.fields import FieldInfo as PydanticFieldInfo
 from pydantic.fields import ModelField, Undefined, UndefinedType
 from pydantic.main import ModelMetaclass, validate_model
-from pydantic.typing import ForwardRef, NoArgAnyCallable, resolve_annotations
+from pydantic.typing import NoArgAnyCallable, resolve_annotations
 from pydantic.utils import ROOT_KEY, Representation
 from sqlalchemy import Boolean, Column, Date, DateTime
 from sqlalchemy import Enum as sa_Enum

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -14,6 +14,7 @@ from sqlalchemy import util
 from sqlalchemy.orm import Query as _Query
 from sqlalchemy.orm import Session as _Session
 from sqlalchemy.sql.base import Executable as _Executable
+from sqlalchemy.sql.selectable import ForUpdateArg as _ForUpdateArg
 from sqlmodel.sql.expression import Select, SelectOfScalar
 from typing_extensions import Literal
 
@@ -136,7 +137,7 @@ class Session(_Session):
         ident: Any,
         options: Optional[Sequence[Any]] = None,
         populate_existing: bool = False,
-        with_for_update: Optional[Union[Literal[True], Mapping[str, Any]]] = None,
+        with_for_update: Optional[_ForUpdateArg] = None,
         identity_token: Optional[Any] = None,
         execution_options: Mapping[Any, Any] = util.EMPTY_DICT,
     ) -> Optional[_TSelectParam]:

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -1,4 +1,14 @@
-from typing import Any, Mapping, Optional, Sequence, Type, TypeVar, Union, overload
+from typing import (
+    Any,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from sqlalchemy import util
 from sqlalchemy.orm import Query as _Query
@@ -21,7 +31,7 @@ class Session(_Session):
         *,
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
         execution_options: Mapping[str, Any] = util.EMPTY_DICT,
-        bind_arguments: Optional[Mapping[str, Any]] = None,
+        bind_arguments: Optional[Dict[str, Any]] = None,
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,
         **kw: Any,
@@ -35,7 +45,7 @@ class Session(_Session):
         *,
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
         execution_options: Mapping[str, Any] = util.EMPTY_DICT,
-        bind_arguments: Optional[Mapping[str, Any]] = None,
+        bind_arguments: Optional[Dict[str, Any]] = None,
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,
         **kw: Any,
@@ -52,7 +62,7 @@ class Session(_Session):
         *,
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
         execution_options: Mapping[str, Any] = util.EMPTY_DICT,
-        bind_arguments: Optional[Mapping[str, Any]] = None,
+        bind_arguments: Optional[Dict[str, Any]] = None,
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,
         **kw: Any,
@@ -75,7 +85,7 @@ class Session(_Session):
         statement: _Executable,
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
         execution_options: Optional[Mapping[str, Any]] = util.EMPTY_DICT,
-        bind_arguments: Optional[Mapping[str, Any]] = None,
+        bind_arguments: Optional[Dict[str, Any]] = None,
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,
         **kw: Any,

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -11,6 +11,7 @@ from typing import (
 )
 
 from sqlalchemy import util
+from sqlalchemy.orm import Mapper as _Mapper
 from sqlalchemy.orm import Query as _Query
 from sqlalchemy.orm import Session as _Session
 from sqlalchemy.sql.base import Executable as _Executable
@@ -133,13 +134,14 @@ class Session(_Session):
 
     def get(
         self,
-        entity: Type[_TSelectParam],
+        entity: Union[Type[_TSelectParam], "_Mapper[_TSelectParam]"],
         ident: Any,
         options: Optional[Sequence[Any]] = None,
         populate_existing: bool = False,
         with_for_update: Optional[_ForUpdateArg] = None,
         identity_token: Optional[Any] = None,
         execution_options: Mapping[Any, Any] = util.EMPTY_DICT,
+        bind_arguments: Optional[Dict[str, Any]] = None,
     ) -> Optional[_TSelectParam]:
         return super().get(
             entity,
@@ -149,4 +151,5 @@ class Session(_Session):
             with_for_update=with_for_update,
             identity_token=identity_token,
             execution_options=execution_options,
+            bind_arguments=bind_arguments
         )

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -84,7 +84,7 @@ class Session(_Session):
         self,
         statement: _Executable,
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
-        execution_options: Optional[Mapping[str, Any]] = util.EMPTY_DICT,
+        execution_options: Mapping[str, Any] = util.EMPTY_DICT,
         bind_arguments: Optional[Dict[str, Any]] = None,
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -138,7 +138,7 @@ class Session(_Session):
         populate_existing: bool = False,
         with_for_update: Optional[Union[Literal[True], Mapping[str, Any]]] = None,
         identity_token: Optional[Any] = None,
-        execution_options: Optional[Mapping[Any, Any]] = util.EMPTY_DICT,
+        execution_options: Mapping[Any, Any] = util.EMPTY_DICT,
     ) -> Optional[_TSelectParam]:
         return super().get(
             entity,

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -23,7 +23,7 @@ from sqlalchemy.sql.expression import Select as _Select
 _TSelect = TypeVar("_TSelect")
 
 
-class Select(_Select[_TSelect], Generic[_TSelect]):
+class Select(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 
@@ -31,7 +31,7 @@ class Select(_Select[_TSelect], Generic[_TSelect]):
 # purpose. This is the same as a normal SQLAlchemy Select class where there's only one
 # entity, so the result will be converted to a scalar by default. This way writing
 # for loops on the results will feel natural.
-class SelectOfScalar(_Select[_TSelect], Generic[_TSelect]):
+class SelectOfScalar(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 

--- a/sqlmodel/sql/expression.py.jinja2
+++ b/sqlmodel/sql/expression.py.jinja2
@@ -20,14 +20,14 @@ from sqlalchemy.sql.expression import Select as _Select
 
 _TSelect = TypeVar("_TSelect")
 
-class Select(_Select[_TSelect], Generic[_TSelect]):
+class Select(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 # This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
 # purpose. This is the same as a normal SQLAlchemy Select class where there's only one
 # entity, so the result will be converted to a scalar by default. This way writing
 # for loops on the results will feel natural.
-class SelectOfScalar(_Select[_TSelect], Generic[_TSelect]):
+class SelectOfScalar(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 


### PR DESCRIPTION
This leaves 3 linting errors for now.

`Result` was streamlined, since SQLAlchemy provides enough typing information in 2.0 we don't need the shim over the base class.